### PR TITLE
Add faq entry for running the Linux installer from terminal

### DIFF
--- a/docs/faq.markdown
+++ b/docs/faq.markdown
@@ -54,3 +54,6 @@ If you get this error while trying to install the CSL model set, it means your u
 Due to macOS security settings, if you receive a "Error reading file..." error when updating xPilot, click the folder icon, choose the X-Plane folder path and try again.
 
 ![Error Reading File](/assets/images/MacOSErrorReadingFile.png)
+
+## Linux: X-Plane install directory textbox not visible in installer
+UI scaling can cause the installer to not show the install directory textbox. The installer can be run in a temrinal with the `--mode text` flag instead.


### PR DESCRIPTION
Came across the issue described in xpilot-project/xpilot#155 while installing xpilot on Fedora 40. 

I think it would make a good addition to the faq just to have `--mode text` option documented.